### PR TITLE
[R4R]update rust version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ We recommend installing Rust through [rustup](https://www.rustup.rs/). If you do
 - Linux:
   ```bash
   $ curl https://sh.rustup.rs -sSf | sh
+  $ rustup default 1.46.0
   ```
 
   OpenEthereum also requires `clang` (>= 9.0), `clang++`, `pkg-config`, `file`, `make`, and `cmake` packages to be installed.
@@ -61,6 +62,7 @@ We recommend installing Rust through [rustup](https://www.rustup.rs/). If you do
 - OSX:
   ```bash
   $ curl https://sh.rustup.rs -sSf | sh
+  $ rustup default 1.46.0
   ```
 
   `clang` is required. It comes with Xcode command line tools or can be installed with homebrew.


### PR DESCRIPTION
### Description
Add the rust version description in the readme doc.

### Rationale
For now, only rust 1.46.0 is available for this release.
### Example

add an example CLI or API response...

### Changes

Just doc change
### Preflight checks

- [ ] build passed (`make build`)
- [ ] tests passed (`make test`)
- [ ] manual transaction test passed

### Already reviewed by

...

### Related issues

... reference related issue #'s here ...
